### PR TITLE
Upgrade to Lucee 7 / jakarta.* (aws-serverless-java-container-core 2.1.5)

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -12,9 +12,9 @@ repositories {
 
 dependencies {
     implementation (
-        'com.amazonaws.serverless:aws-serverless-java-container-core:1.8.2',
-        'javax.servlet.jsp:javax.servlet.jsp-api:2.3.1',
-        'javax.el:javax.el-api:3.0.0',
+        'com.amazonaws.serverless:aws-serverless-java-container-core:2.1.5',
+        'jakarta.servlet.jsp:jakarta.servlet.jsp-api:3.1.1',
+        'jakarta.el:jakarta.el-api:5.0.1',
         'com.amazonaws:aws-xray-recorder-sdk-core:2.15.3',
         'com.amazonaws:aws-lambda-java-log4j2:1.6.0'
     )

--- a/java/src/main/java/com/foundeo/fuseless/ApacheCombinedServletLogFormatter.java
+++ b/java/src/main/java/com/foundeo/fuseless/ApacheCombinedServletLogFormatter.java
@@ -5,10 +5,11 @@ import com.amazonaws.serverless.proxy.LogFormatter;
 
 import com.amazonaws.serverless.proxy.model.AwsProxyRequest;
 import com.amazonaws.serverless.proxy.model.AwsProxyRequestContext;
+import com.amazonaws.serverless.proxy.model.RequestSource;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.ws.rs.core.SecurityContext;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.ws.rs.core.SecurityContext;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -78,7 +79,7 @@ public class ApacheCombinedServletLogFormatter<ContainerRequestType extends Http
         logLineBuilder.append(" ");
 
         // %l
-        if (gatewayContext != null && req.getRequestSource() == AwsProxyRequest.RequestSource.API_GATEWAY) {
+        if (gatewayContext != null && req.getRequestSource() == RequestSource.API_GATEWAY) {
             if (gatewayContext.getIdentity().getUserArn() != null) {
                 logLineBuilder.append(gatewayContext.getIdentity().getUserArn());
             } else {

--- a/java/src/main/java/com/foundeo/fuseless/CFMLLambdaContainerHandler.java
+++ b/java/src/main/java/com/foundeo/fuseless/CFMLLambdaContainerHandler.java
@@ -39,7 +39,7 @@ public class CFMLLambdaContainerHandler<RequestType, ResponseType>
                                                                                          new AwsProxyHttpServletRequestReader(),
                                                                                          new AwsProxyHttpServletResponseWriter(),
                                                                                          new AwsProxySecurityContextWriter(),
-                                                                                         new AwsProxyExceptionHandler()
+                                                                                         new FuseLessExceptionHandler()
                                                                                          );
         newHandler.setLogFormatter(new ApacheCombinedServletLogFormatter<>());
 

--- a/java/src/main/java/com/foundeo/fuseless/CFMLLambdaContainerHandler.java
+++ b/java/src/main/java/com/foundeo/fuseless/CFMLLambdaContainerHandler.java
@@ -13,7 +13,7 @@ import com.amazonaws.xray.AWSXRay;
 import com.amazonaws.xray.entities.Subsegment;
 
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -71,7 +71,7 @@ public class CFMLLambdaContainerHandler<RequestType, ResponseType>
     protected void handleRequest(HttpServletRequest httpServletRequest, AwsHttpServletResponse httpServletResponse, Context lambdaContext)
             throws Exception {
                 
-        RequestWrapper req = new RequestWrapper((javax.servlet.http.HttpServletRequest)httpServletRequest);
+        RequestWrapper req = new RequestWrapper((jakarta.servlet.http.HttpServletRequest)httpServletRequest);
         req.setAttribute("lambdaContext", lambdaContext);
         Object seg = null;
         try {

--- a/java/src/main/java/com/foundeo/fuseless/CFMLServletConfig.java
+++ b/java/src/main/java/com/foundeo/fuseless/CFMLServletConfig.java
@@ -1,9 +1,9 @@
 package com.foundeo.fuseless;
 
-import javax.servlet.*;
+import jakarta.servlet.*;
 import java.util.Enumeration;
 
-public class CFMLServletConfig implements javax.servlet.ServletConfig {
+public class CFMLServletConfig implements jakarta.servlet.ServletConfig {
 		private ServletContext sc;
 
 		public CFMLServletConfig(ServletContext servletContext) {

--- a/java/src/main/java/com/foundeo/fuseless/FuseLessExceptionHandler.java
+++ b/java/src/main/java/com/foundeo/fuseless/FuseLessExceptionHandler.java
@@ -4,8 +4,8 @@ import com.amazonaws.serverless.proxy.AwsProxyExceptionHandler;
 import com.amazonaws.serverless.proxy.model.AwsProxyResponse;
 import com.amazonaws.serverless.proxy.model.Headers;
 
-import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
 
 /**
  * The Lambda runtime interrupts the request-handling thread's CountDownLatch.await() as a

--- a/java/src/main/java/com/foundeo/fuseless/FuseLessExceptionHandler.java
+++ b/java/src/main/java/com/foundeo/fuseless/FuseLessExceptionHandler.java
@@ -1,0 +1,35 @@
+package com.foundeo.fuseless;
+
+import com.amazonaws.serverless.proxy.AwsProxyExceptionHandler;
+import com.amazonaws.serverless.proxy.model.AwsProxyResponse;
+import com.amazonaws.serverless.proxy.model.Headers;
+
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+
+/**
+ * The Lambda runtime interrupts the request-handling thread's CountDownLatch.await() as a
+ * transient signal (not a container shutdown - the next request on the same container succeeds
+ * normally). AwsProxyExceptionHandler's default handling of this returns a 502 with
+ * Content-Type: application/json, which browsers render as a raw JSON blob and which HTML-expecting
+ * clients (e.g. Cypress cy.visit()) reject outright. Override just this case to return HTML instead.
+ */
+public class FuseLessExceptionHandler extends AwsProxyExceptionHandler {
+
+    private static final Headers HTML_HEADERS = new Headers();
+
+    static {
+        HTML_HEADERS.putSingle(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_HTML);
+    }
+
+    @Override
+    public AwsProxyResponse handle(Throwable ex) {
+        if (ex instanceof InterruptedException) {
+            Thread.currentThread().interrupt(); // restore interrupt status
+            StreamLambdaHandler.log("Request interrupted by Lambda runtime", ex);
+            return new AwsProxyResponse(503, HTML_HEADERS,
+                "<html><body><p>Service temporarily unavailable. Please refresh the page.</p></body></html>");
+        }
+        return super.handle(ex);
+    }
+}

--- a/java/src/main/java/com/foundeo/fuseless/RequestWrapper.java
+++ b/java/src/main/java/com/foundeo/fuseless/RequestWrapper.java
@@ -1,7 +1,7 @@
 package com.foundeo.fuseless;
 
-import javax.servlet.http.HttpServletRequestWrapper;
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import jakarta.servlet.http.HttpServletRequest;
 
 public class RequestWrapper extends HttpServletRequestWrapper {
 

--- a/java/src/main/java/com/foundeo/fuseless/ServletContextWrapper.java
+++ b/java/src/main/java/com/foundeo/fuseless/ServletContextWrapper.java
@@ -1,7 +1,7 @@
 package com.foundeo.fuseless;
 
-import javax.servlet.*;
-import javax.servlet.descriptor.JspConfigDescriptor;
+import jakarta.servlet.*;
+import jakarta.servlet.descriptor.JspConfigDescriptor;
 
 import java.io.InputStream;
 import java.net.MalformedURLException;
@@ -86,32 +86,8 @@ public class ServletContextWrapper implements ServletContext {
     }
 
     @Override
-    @Deprecated
-    public Servlet getServlet(String name) throws ServletException {
-        return this.servletContext.getServlet(name);
-    }
-
-    @Override
-    @Deprecated
-    public Enumeration getServlets() {
-        return this.servletContext.getServlets();
-    }
-
-    @Override
-    @Deprecated
-    public Enumeration getServletNames() {
-        return this.servletContext.getServletNames();
-    }
-
-    @Override
     public void log(String msg) {
         this.servletContext.log(msg);
-    }
-
-    @Override
-    @Deprecated
-    public void log(Exception exception, String msg) {
-        this.servletContext.log(exception, msg);
     }
 
     @Override
@@ -190,6 +166,12 @@ public class ServletContextWrapper implements ServletContext {
     @Override
     public ServletRegistration.Dynamic addServlet(String s, Class<? extends Servlet> aClass) {
         return this.servletContext.addServlet(s, aClass);
+    }
+
+
+    @Override
+    public ServletRegistration.Dynamic addJspFile(String s, String s1) {
+        return this.servletContext.addJspFile(s, s1);
     }
 
 
@@ -317,6 +299,42 @@ public class ServletContextWrapper implements ServletContext {
     @Override
     public String getVirtualServerName() {
         return this.servletContext.getVirtualServerName();
+    }
+
+
+    @Override
+    public int getSessionTimeout() {
+        return this.servletContext.getSessionTimeout();
+    }
+
+
+    @Override
+    public void setSessionTimeout(int sessionTimeout) {
+        this.servletContext.setSessionTimeout(sessionTimeout);
+    }
+
+
+    @Override
+    public String getRequestCharacterEncoding() {
+        return this.servletContext.getRequestCharacterEncoding();
+    }
+
+
+    @Override
+    public void setRequestCharacterEncoding(String encoding) {
+        this.servletContext.setRequestCharacterEncoding(encoding);
+    }
+
+
+    @Override
+    public String getResponseCharacterEncoding() {
+        return this.servletContext.getResponseCharacterEncoding();
+    }
+
+
+    @Override
+    public void setResponseCharacterEncoding(String encoding) {
+        this.servletContext.setResponseCharacterEncoding(encoding);
     }
 
 

--- a/java/src/main/java/com/foundeo/fuseless/StreamLambdaHandler.java
+++ b/java/src/main/java/com/foundeo/fuseless/StreamLambdaHandler.java
@@ -5,7 +5,7 @@ import com.amazonaws.serverless.proxy.model.AwsProxyRequest;
 import com.amazonaws.serverless.proxy.model.AwsProxyResponse;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
-import lucee.loader.servlet.CFMLServlet;
+import lucee.loader.servlet.jakarta.CFMLServlet;
 
 import com.amazonaws.services.lambda.runtime.LambdaRuntime;
 import com.amazonaws.services.lambda.runtime.LambdaLogger;
@@ -13,8 +13,8 @@ import com.amazonaws.services.lambda.runtime.LambdaLogger;
 import java.lang.StringBuilder;
 
 
-import javax.servlet.ServletConfig;
-import javax.servlet.http.HttpServlet;
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.http.HttpServlet;
 import java.io.*;
 
 public class StreamLambdaHandler implements RequestStreamHandler {

--- a/test.sh
+++ b/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [[ -z "$LUCEE_VERSION" ]]; then
-	LUCEE_VERSION=5.4.5.23
+	LUCEE_VERSION=7.0.4.34
 fi
 
 if [ -f "java/jars/lucee-light-$LUCEE_VERSION.jar" ]; then

--- a/test.sh
+++ b/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [[ !$LUCEE_VERSION ]]; then
+if [[ -z "$LUCEE_VERSION" ]]; then
 	LUCEE_VERSION=5.4.5.23
 fi
 
@@ -33,9 +33,19 @@ sam local start-api --port 3003 --debug &
 SAM_PID=$!
 
 
-#give it a chance to startup
-echo -e "Sleeping for 5...\n"
-sleep 5
+echo "Waiting for SAM local to be ready..."
+max_wait=60
+elapsed=0
+until curl -s -o /dev/null http://127.0.0.1:3003/ || [ $elapsed -ge $max_wait ]; do
+    sleep 2
+    elapsed=$((elapsed + 2))
+done
+
+if [ $elapsed -ge $max_wait ]; then
+    echo "SAM local did not start within ${max_wait}s"
+    kill $SAM_PID
+    exit 1
+fi
 
 
 echo "Running: http://127.0.0.1:3003/assert.cfm"

--- a/test/build.gradle
+++ b/test/build.gradle
@@ -6,9 +6,9 @@ repositories {
 
 dependencies { 
     implementation (
-        'com.amazonaws.serverless:aws-serverless-java-container-core:1.8.2',
-        'javax.servlet.jsp:javax.servlet.jsp-api:2.3.1',
-        'javax.el:javax.el-api:3.0.0',
+        'com.amazonaws.serverless:aws-serverless-java-container-core:2.1.5',
+        'jakarta.servlet.jsp:jakarta.servlet.jsp-api:3.1.1',
+        'jakarta.el:jakarta.el-api:5.0.1',
         'com.amazonaws:aws-lambda-java-core:1.2.3',
         'com.amazonaws:aws-lambda-java-log4j2:1.6.0'
     )


### PR DESCRIPTION
Migrates javax.* → jakarta.* across FuseLess source, bumps aws-serverless-java-container-core 1.8.2 → 2.1.5 in both java/build.gradle and test/build.gradle, and fixes ServletContextWrapper's changed API signatures for Jakarta Servlet 3.1+.  Depends on https://github.com/foundeo/fuseless/pull/5 and https://github.com/foundeo/fuseless/pull/6 — please merge those first. This branch includes both of their commits as prerequisites; once merged, this PR will reduce to just the Lucee 7 commit. 